### PR TITLE
performance: do not validate actions when rolling back the game state; various tweaks

### DIFF
--- a/Backend/Libraries/Engine/Logic/Abstractions/ActionHandlerBase.cs
+++ b/Backend/Libraries/Engine/Logic/Abstractions/ActionHandlerBase.cs
@@ -5,53 +5,62 @@ using GaiaProject.Engine.Model.Actions;
 
 namespace GaiaProject.Engine.Logic.Abstractions
 {
-	public abstract class ActionHandlerBase<T> : IHandleAction where T : PlayerAction
-	{
-		protected GaiaProjectGame Game;
-		protected PlayerInGame Player;
+    public abstract class ActionHandlerBase<T> : IHandleAction where T : PlayerAction
+    {
+        protected GaiaProjectGame Game;
+        protected PlayerInGame Player;
+        private bool _doValidation = true;
 
-		private void Initialize(GaiaProjectGame game, T action)
-		{
-			Game = game;
-			Player = game.GetPlayer(action.PlayerId);
-			InitializeImpl(game, action);
-		}
+        private void Initialize(GaiaProjectGame game, T action)
+        {
+            Game = game;
+            Player = game.GetPlayer(action.PlayerId);
+            InitializeImpl(game, action);
+        }
 
-		public List<Effect> Handle(GaiaProjectGame game, PlayerAction action)
-		{
-			return Handle(game, action as T);
-		}
+        public List<Effect> Handle(GaiaProjectGame game, PlayerAction action)
+        {
+            return Handle(game, action as T);
+        }
 
-		private List<Effect> Handle(GaiaProjectGame game, T action)
-		{
-			Initialize(game, action);
-			var (isValid, errorMessage) = Validate(game, action);
-			if (!isValid)
-			{
-				throw new InvalidActionException(errorMessage);
-			}
-			return HandleImpl(game, action);
-		}
+        public void ToggleActionValidation(bool on)
+        {
+            this._doValidation = on;
+        }
 
-		/// <summary>
-		/// Initializes the state of the handler
-		/// </summary>
-		protected virtual void InitializeImpl(GaiaProjectGame game, T action) { }
+        private List<Effect> Handle(GaiaProjectGame game, T action)
+        {
+            Initialize(game, action);
+            if (_doValidation)
+            {
+                var (isValid, errorMessage) = Validate(game, action);
+                if (!isValid)
+                {
+                    throw new InvalidActionException(errorMessage);
+                }
+            }
+            return HandleImpl(game, action);
+        }
 
-		/// <summary>
-		/// Actual implementation of the handler
-		/// </summary>
-		/// <param name="game">The game where the action was taken</param>
-		/// <param name="action">The action to apply</param>
-		/// <returns></returns>
-		protected abstract List<Effect> HandleImpl(GaiaProjectGame game, T action);
+        /// <summary>
+        /// Initializes the state of the handler
+        /// </summary>
+        protected virtual void InitializeImpl(GaiaProjectGame game, T action) { }
 
-		/// <summary>
-		/// Validates the action against the current game state
-		/// </summary>
-		/// <param name="game">The game where the action should be taken</param>
-		/// <param name="action">The action to validate</param>
-		/// <returns></returns>
-		protected abstract (bool isValid, string errorMessage) Validate(GaiaProjectGame game, T action);
-	}
+        /// <summary>
+        /// Actual implementation of the handler
+        /// </summary>
+        /// <param name="game">The game where the action was taken</param>
+        /// <param name="action">The action to apply</param>
+        /// <returns></returns>
+        protected abstract List<Effect> HandleImpl(GaiaProjectGame game, T action);
+
+        /// <summary>
+        /// Validates the action against the current game state
+        /// </summary>
+        /// <param name="game">The game where the action should be taken</param>
+        /// <param name="action">The action to validate</param>
+        /// <returns></returns>
+        protected abstract (bool isValid, string errorMessage) Validate(GaiaProjectGame game, T action);
+    }
 }

--- a/Backend/Libraries/Engine/Logic/Abstractions/IHandleAction.cs
+++ b/Backend/Libraries/Engine/Logic/Abstractions/IHandleAction.cs
@@ -5,17 +5,23 @@ using GaiaProject.Engine.Model.Actions;
 
 namespace GaiaProject.Engine.Logic.Abstractions
 {
-	/// <summary>
-	/// Interface implemented by classes than can handle actions
-	/// </summary>
-	public interface IHandleAction
-	{
-		/// <summary>
-		/// Handles an action and returns the effects caused by the action
-		/// </summary>
-		/// <param name="game">The game where the action was taken</param>
-		/// <param name="action">The action to apply</param>
-		/// <returns></returns>
-		List<Effect> Handle(GaiaProjectGame game, PlayerAction action);
-	}
+    /// <summary>
+    /// Interface implemented by classes than can handle actions
+    /// </summary>
+    public interface IHandleAction
+    {
+        /// <summary>
+        /// Handles an action and returns the effects caused by the action
+        /// </summary>
+        /// <param name="game">The game where the action was taken</param>
+        /// <param name="action">The action to apply</param>
+        /// <returns></returns>
+        List<Effect> Handle(GaiaProjectGame game, PlayerAction action);
+
+        /// <summary>
+        /// Enables or disables action validation (e.g.: off when reconstructing the game state by reapplying all actions)
+        /// </summary>
+        /// <returns></returns>
+        void ToggleActionValidation(bool on);
+    }
 }

--- a/Backend/Libraries/Engine/Logic/Entities/Effects/FederationCreatedEffect.cs
+++ b/Backend/Libraries/Engine/Logic/Entities/Effects/FederationCreatedEffect.cs
@@ -1,28 +1,36 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using GaiaProject.Engine.Enums;
 using GaiaProject.Engine.Model;
 using GaiaProject.Engine.Model.Board;
+using GaiaProject.Engine.Model.Players;
 
 namespace GaiaProject.Engine.Logic.Entities.Effects
 {
-	public class IvitsFederationExpandedEffect : Effect
-	{
-		public List<Hex> FederatedHexes { get; }
+    public class FederationCreatedEffect : Effect
+    {
+        public List<Hex> FederatedHexes { get; }
 
-		public IvitsFederationExpandedEffect(List<Hex> federatedHexes)
-		{
-			FederatedHexes = federatedHexes;
-		}
+        public FederationCreatedEffect(List<Hex> federatedHexes)
+        {
+            FederatedHexes = federatedHexes;
+        }
 
-		public override void ApplyTo(GaiaProjectGame game)
-		{
-			var player = game.GetPlayer(PlayerId);
-			var federation = player.State.Federations.Single();
-			federation.HexIds.AddRange(FederatedHexes.Select(h => h.Id));
-			federation.NumBuildings += FederatedHexes.Count(h => h.Buildings.Any());
-			federation.TotalPowerValue += FederatedHexes
-				.Select(h => h.Buildings.SingleOrDefault(b => b.PlayerId == PlayerId)?.PowerValueInFederation ?? 0)
-				.Sum();
-		}
-	}
+        public override void ApplyTo(GaiaProjectGame game)
+        {
+            var player = game.GetPlayer(PlayerId);
+            var counter = player.State.Federations.Count() + 1;
+            var newFederation = Federation.FromBuildings(PlayerId, counter, FederatedHexes);
+            player.State.Federations.Add(newFederation);
+
+            // If the federation has no satellites, mark one of the buildings with the Federation Marker
+            var buildings = FederatedHexes.SelectMany(h => h.Buildings).ToList();
+            if (buildings.Any(b => b.Type == BuildingType.Satellite || b.Type == BuildingType.IvitsSpaceStation))
+            {
+                return;
+            }
+            var buildingToMark = buildings.OrderByDescending(b => b.PowerValueInFederation).First();
+            buildingToMark.ShowFederationMarker = true;
+        }
+    }
 }

--- a/Backend/Libraries/Engine/Logic/Entities/Effects/IncomeVariationEffect.cs
+++ b/Backend/Libraries/Engine/Logic/Entities/Effects/IncomeVariationEffect.cs
@@ -4,21 +4,21 @@ using GaiaProject.Engine.Model;
 
 namespace GaiaProject.Engine.Logic.Entities.Effects
 {
-	public class IncomeVariationEffect : Effect
-	{
-		public IncomeSource Source { get; set; }
+    public class IncomeVariationEffect : Effect
+    {
+        public IncomeSource Source { get; set; }
 
-		public IncomeVariationEffect(IncomeSource source)
-		{
-			Source = source;
-		}
+        public IncomeVariationEffect(IncomeSource source)
+        {
+            Source = source;
+        }
 
-		public override void ApplyTo(GaiaProjectGame game)
-		{
-			var player = game.GetPlayer(PlayerId);
-			player.State.Incomes = IncomeUtils.UpdateIncomeFrom(Source, player);
-
-			game.LogEffect(this, "incomes have been updated");
-		}
-	}
+        public override void ApplyTo(GaiaProjectGame game)
+        {
+            var player = game.GetPlayer(PlayerId);
+            player.State.Incomes = IncomeUtils.UpdateIncomeFrom(Source, player);
+            // The following log is arguably useless
+            // game.LogEffect(this, "incomes have been updated");
+        }
+    }
 }

--- a/Backend/Libraries/Engine/Logic/Entities/Effects/IvitsFederationExpandedEffect.cs
+++ b/Backend/Libraries/Engine/Logic/Entities/Effects/IvitsFederationExpandedEffect.cs
@@ -2,25 +2,27 @@
 using System.Linq;
 using GaiaProject.Engine.Model;
 using GaiaProject.Engine.Model.Board;
-using GaiaProject.Engine.Model.Players;
 
 namespace GaiaProject.Engine.Logic.Entities.Effects
 {
-	public class FederationCreatedEffect : Effect
-	{
-		public List<Hex> FederatedHexes { get; }
+    public class IvitsFederationExpandedEffect : Effect
+    {
+        public List<Hex> FederatedHexes { get; }
 
-		public FederationCreatedEffect(List<Hex> federatedHexes)
-		{
-			FederatedHexes = federatedHexes;
-		}
+        public IvitsFederationExpandedEffect(List<Hex> federatedHexes)
+        {
+            FederatedHexes = federatedHexes;
+        }
 
-		public override void ApplyTo(GaiaProjectGame game)
-		{
-			var player = game.GetPlayer(PlayerId);
-			var counter = player.State.Federations.Count() + 1;
-			var newFederation = Federation.FromBuildings(PlayerId, counter, FederatedHexes);
-			player.State.Federations.Add(newFederation);
-		}
-	}
+        public override void ApplyTo(GaiaProjectGame game)
+        {
+            var player = game.GetPlayer(PlayerId);
+            var federation = player.State.Federations.Single();
+            federation.HexIds.AddRange(FederatedHexes.Select(h => h.Id));
+            federation.NumBuildings += FederatedHexes.Count(h => h.Buildings.Any());
+            federation.TotalPowerValue += FederatedHexes
+                .Select(h => h.Buildings.SingleOrDefault(b => b.PlayerId == PlayerId)?.PowerValueInFederation ?? 0)
+                .Sum();
+        }
+    }
 }

--- a/Backend/Libraries/Engine/Model/Board/Building.cs
+++ b/Backend/Libraries/Engine/Model/Board/Building.cs
@@ -4,66 +4,69 @@ using MongoDB.Bson.Serialization.Attributes;
 
 namespace GaiaProject.Engine.Model.Board
 {
-	[BsonNoId]
-	public class Building
-	{
-		public string Id { get; set; }
-		public BuildingType Type { get; set; }
-		public string PlayerId { get; set; }
-		public Race RaceId { get; set; }
-		public string HexId { get; set; }
-		public int PowerValue { get; set; }
+    [BsonNoId]
+    public class Building
+    {
+        public string Id { get; set; }
+        public BuildingType Type { get; set; }
+        public string PlayerId { get; set; }
+        public Race RaceId { get; set; }
+        public string HexId { get; set; }
+        public int PowerValue { get; set; }
 
-		public int PowerValueInFederation => RaceId == Race.Ivits && Type == BuildingType.IvitsSpaceStation
-			? PowerValue + 1
-			: PowerValue;
+        [BsonIgnoreIfDefault]
+        public bool ShowFederationMarker { get; set; }
 
-		private Building() { }
+        public int PowerValueInFederation => RaceId == Race.Ivits && Type == BuildingType.IvitsSpaceStation
+            ? PowerValue + 1
+            : PowerValue;
 
-		public static class Factory
-		{
-			public static Building Create(BuildingType type, PlayerInGame player, string hexId, PlanetType? planetType)
-			{
-				return new Building
-				{
-					Id = $"{hexId}_{player.Id}",
-					Type = type,
-					PlayerId = player.Id,
-					RaceId = player.RaceId!.Value,
-					HexId = hexId,
-					PowerValue = GetActualPowerValue(type, planetType, player)
-				};
-			}
+        private Building() { }
 
-			private static int GetActualPowerValue(BuildingType type, PlanetType? planetType, PlayerInGame player)
-			{
-				int value;
-				switch (type)
-				{
-					default:
-					case BuildingType.Gaiaformer:
-					case BuildingType.Satellite:
-					case BuildingType.IvitsSpaceStation:
-						return 0;
-					case BuildingType.LostPlanet:
-						return 1;
-					case BuildingType.Mine:
-						value = 1;
-						break;
-					case BuildingType.TradingStation:
-					case BuildingType.ResearchLab:
-						value = 2;
-						break;
-					case BuildingType.PlanetaryInstitute:
-					case BuildingType.AcademyLeft:
-					case BuildingType.AcademyRight:
-						var hasStandardTile = player.State.StandardTechnologyTiles.Any(st => st.Id == StandardTechnologyTileType.PassiveBigBuildingsWorth4Power);
-						value = hasStandardTile ? 4 : 3;
-						break;
-				}
-				var isBescodsWithPlanetaryInstitute = player.RaceId == Race.Bescods && player.State.Buildings.PlanetaryInstitute;
-				return value + (isBescodsWithPlanetaryInstitute && planetType == PlanetType.Titanium ? 1 : 0);
-			}
-		}
-	}
+        public static class Factory
+        {
+            public static Building Create(BuildingType type, PlayerInGame player, string hexId, PlanetType? planetType)
+            {
+                return new Building
+                {
+                    Id = $"{hexId}_{player.Id}",
+                    Type = type,
+                    PlayerId = player.Id,
+                    RaceId = player.RaceId!.Value,
+                    HexId = hexId,
+                    PowerValue = GetActualPowerValue(type, planetType, player)
+                };
+            }
+
+            private static int GetActualPowerValue(BuildingType type, PlanetType? planetType, PlayerInGame player)
+            {
+                int value;
+                switch (type)
+                {
+                    default:
+                    case BuildingType.Gaiaformer:
+                    case BuildingType.Satellite:
+                    case BuildingType.IvitsSpaceStation:
+                        return 0;
+                    case BuildingType.LostPlanet:
+                        return 1;
+                    case BuildingType.Mine:
+                        value = 1;
+                        break;
+                    case BuildingType.TradingStation:
+                    case BuildingType.ResearchLab:
+                        value = 2;
+                        break;
+                    case BuildingType.PlanetaryInstitute:
+                    case BuildingType.AcademyLeft:
+                    case BuildingType.AcademyRight:
+                        var hasStandardTile = player.State.StandardTechnologyTiles.Any(st => st.Id == StandardTechnologyTileType.PassiveBigBuildingsWorth4Power);
+                        value = hasStandardTile ? 4 : 3;
+                        break;
+                }
+                var isBescodsWithPlanetaryInstitute = player.RaceId == Race.Bescods && player.State.Buildings.PlanetaryInstitute;
+                return value + (isBescodsWithPlanetaryInstitute && planetType == PlanetType.Titanium ? 1 : 0);
+            }
+        }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/BoardStateViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/BoardStateViewModel.cs
@@ -2,61 +2,12 @@ using System.Collections.Generic;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class BoardStateViewModel
-	{
-		private MapViewModel _map;
-		public MapViewModel Map
-		{
-			get => _map;
-			set
-			{
-				if (_map == value) return;
-				_map = value;
-			}
-		}
-
-		private ScoringBoardViewModel _scoringBoard;
-		public ScoringBoardViewModel ScoringBoard
-		{
-			get => _scoringBoard;
-			set
-			{
-				if (_scoringBoard == value) return;
-				_scoringBoard = value;
-			}
-		}
-
-		private ResearchBoardViewModel _researchBoard;
-		public ResearchBoardViewModel ResearchBoard
-		{
-			get => _researchBoard;
-			set
-			{
-				if (_researchBoard == value) return;
-				_researchBoard = value;
-			}
-		}
-
-		private List<RoundBoosterTileViewModel> _availableRoundBoosters;
-		public List<RoundBoosterTileViewModel> AvailableRoundBoosters
-		{
-			get => _availableRoundBoosters;
-			set
-			{
-				if (_availableRoundBoosters == value) return;
-				_availableRoundBoosters = value;
-			}
-		}
-
-		private List<FederationTokenStackViewModel> _availableFederations;
-		public List<FederationTokenStackViewModel> AvailableFederations
-		{
-			get => _availableFederations;
-			set
-			{
-				if (_availableFederations == value) return;
-				_availableFederations = value;
-			}
-		}
-	}
+    public class BoardStateViewModel
+    {
+        public MapViewModel Map { get; set; }
+        public ScoringBoardViewModel ScoringBoard { get; set; }
+        public ResearchBoardViewModel ResearchBoard { get; set; }
+        public List<RoundBoosterTileViewModel> AvailableRoundBoosters { get; set; }
+        public List<FederationTokenStackViewModel> AvailableFederations { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/BuildingViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/BuildingViewModel.cs
@@ -2,72 +2,14 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class BuildingViewModel
-	{
-		private string _username;
-		public string Username
-		{
-			get => _username;
-			set
-			{
-				if (_username == value) return;
-				_username = value;
-			}
-		}
-
-		private Race _raceId;
-		public Race RaceId
-		{
-			get => _raceId;
-			set
-			{
-				if (_raceId == value) return;
-				_raceId = value;
-			}
-		}
-
-		private BuildingType _type;
-		public BuildingType Type
-		{
-			get => _type;
-			set
-			{
-				if (_type == value) return;
-				_type = value;
-			}
-		}
-
-		private int _powerValue;
-		public int PowerValue
-		{
-			get => _powerValue;
-			set
-			{
-				if (_powerValue == value) return;
-				_powerValue = value;
-			}
-		}
-
-		private int _powerValueInFederation;
-		public int PowerValueInFederation
-		{
-			get => _powerValueInFederation;
-			set
-			{
-				if (_powerValueInFederation == value) return;
-				_powerValueInFederation = value;
-			}
-		}
-
-		private string _federationId;
-		public string FederationId
-		{
-			get => _federationId;
-			set
-			{
-				if (_federationId == value) return;
-				_federationId = value;
-			}
-		}
-	}
+    public class BuildingViewModel
+    {
+        public string Username { get; set; }
+        public Race RaceId { get; set; }
+        public BuildingType Type { get; set; }
+        public int PowerValue { get; set; }
+        public int PowerValueInFederation { get; set; }
+        public string FederationId { get; set; }
+        public bool ShowFederationMarker { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/FederationTokenStackViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/FederationTokenStackViewModel.cs
@@ -2,39 +2,10 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class FederationTokenStackViewModel
-	{
-		private FederationTokenType _type;
-		public FederationTokenType Type
-		{
-			get => _type;
-			set
-			{
-				if (_type == value) return;
-				_type = value;
-			}
-		}
-
-		private int _initialQuantity;
-		public int InitialQuantity
-		{
-			get => _initialQuantity;
-			set
-			{
-				if (_initialQuantity == value) return;
-				_initialQuantity = value;
-			}
-		}
-
-		private int _remaining;
-		public int Remaining
-		{
-			get => _remaining;
-			set
-			{
-				if (_remaining == value) return;
-				_remaining = value;
-			}
-		}
-	}
+    public class FederationTokenStackViewModel
+    {
+        public FederationTokenType Type { get; set; }
+        public int InitialQuantity { get; set; }
+        public int Remaining { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/FinalScoringStateViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/FinalScoringStateViewModel.cs
@@ -4,64 +4,16 @@ using GaiaProject.ViewModels.Players;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class FinalScoringStateViewModel
-	{
-		public class PlayerFinalScoringStatusViewModel
-		{
-			private PlayerInfoViewModel _player;
-			public PlayerInfoViewModel Player
-			{
-				get => _player;
-				set
-				{
-					if (_player == value) return;
-					_player = value;
-				}
-			}
+    public class FinalScoringStateViewModel
+    {
+        public class PlayerFinalScoringStatusViewModel
+        {
+            public PlayerInfoViewModel Player { get; set; }
+            public int Count { get; set; }
+            public int Points { get; set; }
+        }
 
-			private int _count;
-			public int Count
-			{
-				get => _count;
-				set
-				{
-					if (_count == value) return;
-					_count = value;
-				}
-			}
-
-			private int _points;
-			public int Points
-			{
-				get => _points;
-				set
-				{
-					if (_points == value) return;
-					_points = value;
-				}
-			}
-		}
-
-		private FinalScoringTileType _tileId;
-		public FinalScoringTileType TileId
-		{
-			get => _tileId;
-			set
-			{
-				if (_tileId == value) return;
-				_tileId = value;
-			}
-		}
-
-		private List<PlayerFinalScoringStatusViewModel> _players;
-		public List<PlayerFinalScoringStatusViewModel> Players
-		{
-			get => _players;
-			set
-			{
-				if (_players == value) return;
-				_players = value;
-			}
-		}
-	}
+        public FinalScoringTileType TileId { get; set; }
+        public List<PlayerFinalScoringStatusViewModel> Players { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/HexViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/HexViewModel.cs
@@ -3,116 +3,17 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class HexViewModel
-	{
-		private string _id;
-		public string Id
-		{
-			get => _id;
-			set
-			{
-				if (_id == value) return;
-				_id = value;
-			}
-		}
-
-		private int _index;
-		public int Index
-		{
-			get => _index;
-			set
-			{
-				if (_index == value) return;
-				_index = value;
-			}
-		}
-
-		private int _row;
-		public int Row
-		{
-			get => _row;
-			set
-			{
-				if (_row == value) return;
-				_row = value;
-			}
-		}
-
-		private int _column;
-		public int Column
-		{
-			get => _column;
-			set
-			{
-				if (_column == value) return;
-				_column = value;
-			}
-		}
-
-		private PlanetType? _planetType;
-		public PlanetType? PlanetType
-		{
-			get => _planetType;
-			set
-			{
-				if (_planetType == value) return;
-				_planetType = value;
-			}
-		}
-
-		private bool _wasGaiaformed;
-		public bool WasGaiaformed
-		{
-			get => _wasGaiaformed;
-			set
-			{
-				if (_wasGaiaformed == value) return;
-				_wasGaiaformed = value;
-			}
-		}
-
-		private BuildingViewModel _building;
-		public BuildingViewModel Building
-		{
-			get => _building;
-			set
-			{
-				if (_building == value) return;
-				_building = value;
-			}
-		}
-
-		private BuildingViewModel _lantidsParasiteBuilding;
-		public BuildingViewModel LantidsParasiteBuilding
-		{
-			get => _lantidsParasiteBuilding;
-			set
-			{
-				if (_lantidsParasiteBuilding == value) return;
-				_lantidsParasiteBuilding = value;
-			}
-		}
-
-		private BuildingViewModel _ivitsSpaceStation;
-		public BuildingViewModel IvitsSpaceStation
-		{
-			get => _ivitsSpaceStation;
-			set
-			{
-				if (_ivitsSpaceStation == value) return;
-				_ivitsSpaceStation = value;
-			}
-		}
-
-		private List<BuildingViewModel> _satellites;
-		public List<BuildingViewModel> Satellites
-		{
-			get => _satellites;
-			set
-			{
-				if (_satellites == value) return;
-				_satellites = value;
-			}
-		}
-	}
+    public class HexViewModel
+    {
+        public string Id { get; set; }
+        public int Index { get; set; }
+        public int Row { get; set; }
+        public int Column { get; set; }
+        public PlanetType? PlanetType { get; set; }
+        public bool WasGaiaformed { get; set; }
+        public BuildingViewModel Building { get; set; }
+        public BuildingViewModel LantidsParasiteBuilding { get; set; }
+        public BuildingViewModel IvitsSpaceStation { get; set; }
+        public List<BuildingViewModel> Satellites { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/MapViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/MapViewModel.cs
@@ -4,66 +4,17 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class MapViewModel
-	{
-		private int _playerCount;
-		public int PlayerCount
-		{
-			get => _playerCount;
-			set
-			{
-				if (_playerCount == value) return;
-				_playerCount = value;
-			}
-		}
+    public class MapViewModel
+    {
+        public int PlayerCount { get; set; }
+        public int Rows { get; set; }
+        public int Columns { get; set; }
+        public MapShape Shape { get; set; }
+        public List<SectorViewModel> Sectors { get; set; }
 
-		private int _rows;
-		public int Rows
-		{
-			get => _rows;
-			set
-			{
-				if (_rows == value) return;
-				_rows = value;
-			}
-		}
-
-		private int _columns;
-		public int Columns
-		{
-			get => _columns;
-			set
-			{
-				if (_columns == value) return;
-				_columns = value;
-			}
-		}
-
-		private MapShape _shape;
-		public MapShape Shape
-		{
-			get => _shape;
-			set
-			{
-				if (_shape == value) return;
-				_shape = value;
-			}
-		}
-
-		private List<SectorViewModel> _sectors;
-		public List<SectorViewModel> Sectors
-		{
-			get => _sectors;
-			set
-			{
-				if (_sectors == value) return;
-				_sectors = value;
-			}
-		}
-
-		public HexViewModel GetHex(string id)
-		{
-			return Sectors.SelectMany(s => s.Hexes).Single(h => h.Id == id);
-		}
-	}
+        public HexViewModel GetHex(string id)
+        {
+            return Sectors.SelectMany(s => s.Hexes).Single(h => h.Id == id);
+        }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/PlayerAdvancementViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/PlayerAdvancementViewModel.cs
@@ -2,28 +2,9 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class PlayerAdvancementViewModel
-	{
-		private Race _raceId;
-		public Race RaceId
-		{
-			get => _raceId;
-			set
-			{
-				if (_raceId == value) return;
-				_raceId = value;
-			}
-		}
-
-		private int _steps;
-		public int Steps
-		{
-			get => _steps;
-			set
-			{
-				if (_steps == value) return;
-				_steps = value;
-			}
-		}
-	}
+    public class PlayerAdvancementViewModel
+    {
+        public Race RaceId { get; set; }
+        public int Steps { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/PowerActionSpaceViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/PowerActionSpaceViewModel.cs
@@ -2,30 +2,10 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class PowerActionSpaceViewModel : IActionSpaceViewModel<PowerActionType>
-	{
-		public string Kind => "power";
-
-		private PowerActionType _type;
-		public PowerActionType Type
-		{
-			get => _type;
-			set
-			{
-				if (_type == value) return;
-				_type = value;
-			}
-		}
-
-		private bool _isAvailable;
-		public bool IsAvailable
-		{
-			get => _isAvailable;
-			set
-			{
-				if (_isAvailable == value) return;
-				_isAvailable = value;
-			}
-		}
-	}
+    public class PowerActionSpaceViewModel : IActionSpaceViewModel<PowerActionType>
+    {
+        public string Kind => "power";
+        public PowerActionType Type { get; set; }
+        public bool IsAvailable { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/QicActionSpaceViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/QicActionSpaceViewModel.cs
@@ -2,30 +2,10 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class QicActionSpaceViewModel : IActionSpaceViewModel<QicActionType>
-	{
-		public string Kind => "qic";
-
-		private QicActionType _type;
-		public QicActionType Type
-		{
-			get => _type;
-			set
-			{
-				if (_type == value) return;
-				_type = value;
-			}
-		}
-
-		private bool _isAvailable;
-		public bool IsAvailable
-		{
-			get => _isAvailable;
-			set
-			{
-				if (_isAvailable == value) return;
-				_isAvailable = value;
-			}
-		}
-	}
+    public class QicActionSpaceViewModel : IActionSpaceViewModel<QicActionType>
+    {
+        public string Kind => "qic";
+        public QicActionType Type { get; set; }
+        public bool IsAvailable { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/ResearchBoardViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/ResearchBoardViewModel.cs
@@ -2,50 +2,11 @@ using System.Collections.Generic;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class ResearchBoardViewModel
-	{
-		private List<ResearchTrackViewModel> _tracks;
-		public List<ResearchTrackViewModel> Tracks
-		{
-			get => _tracks;
-			set
-			{
-				if (_tracks == value) return;
-				_tracks = value;
-			}
-		}
-
-		private List<StandardTechnologyTileStackViewModel> _freeStandardTiles;
-		public List<StandardTechnologyTileStackViewModel> FreeStandardTiles
-		{
-			get => _freeStandardTiles;
-			set
-			{
-				if (_freeStandardTiles == value) return;
-				_freeStandardTiles = value;
-			}
-		}
-
-		private List<PowerActionSpaceViewModel> _powerActions;
-		public List<PowerActionSpaceViewModel> PowerActions
-		{
-			get => _powerActions;
-			set
-			{
-				if (_powerActions == value) return;
-				_powerActions = value;
-			}
-		}
-
-		private List<QicActionSpaceViewModel> _qicActions;
-		public List<QicActionSpaceViewModel> QicActions
-		{
-			get => _qicActions;
-			set
-			{
-				if (_qicActions == value) return;
-				_qicActions = value;
-			}
-		}
-	}
+    public class ResearchBoardViewModel
+    {
+        public List<ResearchTrackViewModel> Tracks { get; set; }
+        public List<StandardTechnologyTileStackViewModel> FreeStandardTiles { get; set; }
+        public List<PowerActionSpaceViewModel> PowerActions { get; set; }
+        public List<QicActionSpaceViewModel> QicActions { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/ResearchTrackViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/ResearchTrackViewModel.cs
@@ -3,72 +3,13 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class ResearchTrackViewModel
-	{
-		private ResearchTrackType _id;
-		public ResearchTrackType Id
-		{
-			get => _id;
-			set
-			{
-				if (_id == value) return;
-				_id = value;
-			}
-		}
-
-		private List<PlayerAdvancementViewModel> _players;
-		public List<PlayerAdvancementViewModel> Players
-		{
-			get => _players;
-			set
-			{
-				if (_players == value) return;
-				_players = value;
-			}
-		}
-
-		private StandardTechnologyTileStackViewModel _standardTiles;
-		public StandardTechnologyTileStackViewModel StandardTiles
-		{
-			get => _standardTiles;
-			set
-			{
-				if (_standardTiles == value) return;
-				_standardTiles = value;
-			}
-		}
-
-		private AdvancedTechnologyTileType? _advancedTileType;
-		public AdvancedTechnologyTileType? AdvancedTileType
-		{
-			get => _advancedTileType;
-			set
-			{
-				if (_advancedTileType == value) return;
-				_advancedTileType = value;
-			}
-		}
-
-		private FederationTokenType? _federation;
-		public FederationTokenType? Federation
-		{
-			get => _federation;
-			set
-			{
-				if (_federation == value) return;
-				_federation = value;
-			}
-		}
-
-		private bool _lostPlanet;
-		public bool LostPlanet
-		{
-			get => _lostPlanet;
-			set
-			{
-				if (_lostPlanet == value) return;
-				_lostPlanet = value;
-			}
-		}
-	}
+    public class ResearchTrackViewModel
+    {
+        public ResearchTrackType Id { get; set; }
+        public List<PlayerAdvancementViewModel> Players { get; set; }
+        public StandardTechnologyTileStackViewModel StandardTiles { get; set; }
+        public AdvancedTechnologyTileType? AdvancedTileType { get; set; }
+        public FederationTokenType? Federation { get; set; }
+        public bool LostPlanet { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/RoundBoosterTileViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/RoundBoosterTileViewModel.cs
@@ -3,50 +3,11 @@ using GaiaProject.ViewModels.Players;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class RoundBoosterTileViewModel
-	{
-		private RoundBoosterType _id;
-		public RoundBoosterType Id
-		{
-			get => _id;
-			set
-			{
-				if (_id == value) return;
-				_id = value;
-			}
-		}
-
-		private bool _isTaken;
-		public bool IsTaken
-		{
-			get => _isTaken;
-			set
-			{
-				if (_isTaken == value) return;
-				_isTaken = value;
-			}
-		}
-
-		private PlayerInfoViewModel _player;
-		public PlayerInfoViewModel Player
-		{
-			get => _player;
-			set
-			{
-				if (_player == value) return;
-				_player = value;
-			}
-		}
-
-		private bool _used;
-		public bool Used
-		{
-			get => _used;
-			set
-			{
-				if (_used == value) return;
-				_used = value;
-			}
-		}
-	}
+    public class RoundBoosterTileViewModel
+    {
+        public RoundBoosterType Id { get; set; }
+        public bool IsTaken { get; set; }
+        public PlayerInfoViewModel Player { get; set; }
+        public bool Used { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/ScoringBoardViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/ScoringBoardViewModel.cs
@@ -2,39 +2,10 @@ using System.Collections.Generic;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class ScoringBoardViewModel
-	{
-		private List<ScoringTileViewModel> _scoringTiles;
-		public List<ScoringTileViewModel> ScoringTiles
-		{
-			get => _scoringTiles;
-			set
-			{
-				if (_scoringTiles == value) return;
-				_scoringTiles = value;
-			}
-		}
-
-		private FinalScoringStateViewModel _finalScoring1;
-		public FinalScoringStateViewModel FinalScoring1
-		{
-			get => _finalScoring1;
-			set
-			{
-				if (_finalScoring1 == value) return;
-				_finalScoring1 = value;
-			}
-		}
-
-		private FinalScoringStateViewModel _finalScoring2;
-		public FinalScoringStateViewModel FinalScoring2
-		{
-			get => _finalScoring2;
-			set
-			{
-				if (_finalScoring2 == value) return;
-				_finalScoring2 = value;
-			}
-		}
-	}
+    public class ScoringBoardViewModel
+    {
+        public List<ScoringTileViewModel> ScoringTiles { get; set; }
+        public FinalScoringStateViewModel FinalScoring1 { get; set; }
+        public FinalScoringStateViewModel FinalScoring2 { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/ScoringTileViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/ScoringTileViewModel.cs
@@ -2,39 +2,10 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class ScoringTileViewModel
-	{
-		private RoundScoringTileType _tileId;
-		public RoundScoringTileType TileId
-		{
-			get => _tileId;
-			set
-			{
-				if (_tileId == value) return;
-				_tileId = value;
-			}
-		}
-
-		private int _roundNumber;
-		public int RoundNumber
-		{
-			get => _roundNumber;
-			set
-			{
-				if (_roundNumber == value) return;
-				_roundNumber = value;
-			}
-		}
-
-		private bool _inactive;
-		public bool Inactive
-		{
-			get => _inactive;
-			set
-			{
-				if (_inactive == value) return;
-				_inactive = value;
-			}
-		}
-	}
+    public class ScoringTileViewModel
+    {
+        public RoundScoringTileType TileId { get; set; }
+        public int RoundNumber { get; set; }
+        public bool Inactive { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/SectorViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/SectorViewModel.cs
@@ -2,72 +2,13 @@
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class SectorViewModel
-	{
-		private string _id;
-		public string Id
-		{
-			get => _id;
-			set
-			{
-				if (_id == value) return;
-				_id = value;
-			}
-		}
-
-		private int _number;
-		public int Number
-		{
-			get => _number;
-			set
-			{
-				if (_number == value) return;
-				_number = value;
-			}
-		}
-
-		private int _rotation;
-		public int Rotation
-		{
-			get => _rotation;
-			set
-			{
-				if (_rotation == value) return;
-				_rotation = value;
-			}
-		}
-
-		private int _row;
-		public int Row
-		{
-			get => _row;
-			set
-			{
-				if (_row == value) return;
-				_row = value;
-			}
-		}
-
-		private int _column;
-		public int Column
-		{
-			get => _column;
-			set
-			{
-				if (_column == value) return;
-				_column = value;
-			}
-		}
-
-		private List<HexViewModel> _hexes;
-		public List<HexViewModel> Hexes
-		{
-			get => _hexes;
-			set
-			{
-				if (_hexes == value) return;
-				_hexes = value;
-			}
-		}
-	}
+    public class SectorViewModel
+    {
+        public string Id { get; set; }
+        public int Number { get; set; }
+        public int Rotation { get; set; }
+        public int Row { get; set; }
+        public int Column { get; set; }
+        public List<HexViewModel> Hexes { get; set; }
+    }
 }

--- a/Backend/Libraries/ViewModels/Board/TechnologyTileStackViewModel.cs
+++ b/Backend/Libraries/ViewModels/Board/TechnologyTileStackViewModel.cs
@@ -2,39 +2,10 @@ using GaiaProject.Engine.Enums;
 
 namespace GaiaProject.ViewModels.Board
 {
-	public class StandardTechnologyTileStackViewModel
-	{
-		private StandardTechnologyTileType _type;
-		public StandardTechnologyTileType Type
-		{
-			get => _type;
-			set
-			{
-				if (_type == value) return;
-				_type = value;
-			}
-		}
-
-		private int _total;
-		public int Total
-		{
-			get => _total;
-			set
-			{
-				if (_total == value) return;
-				_total = value;
-			}
-		}
-
-		private int _remaining;
-		public int Remaining
-		{
-			get => _remaining;
-			set
-			{
-				if (_remaining == value) return;
-				_remaining = value;
-			}
-		}
-	}
+    public class StandardTechnologyTileStackViewModel
+    {
+        public StandardTechnologyTileType Type { get; set; }
+        public int Total { get; set; }
+        public int Remaining { get; set; }
+    }
 }

--- a/Frontend/StarGate/src/dto/interfaces.ts
+++ b/Frontend/StarGate/src/dto/interfaces.ts
@@ -393,6 +393,7 @@ export interface BuildingDto {
 	powerValue: number;
 	powerValueInFederation: number;
 	federationId: string;
+	showFederationMarker: boolean;
 }
 
 export interface HexDto {

--- a/Frontend/StarGate/src/game-page/GamePage.tsx
+++ b/Frontend/StarGate/src/game-page/GamePage.tsx
@@ -86,26 +86,26 @@ const GamePage = () => {
 	const [activeViewDimensions, setActiveViewDimensions] = useState<Nullable<ElementSize>>(null);
 	const [activeWorkflow, setActiveWorkflow] = useState<Nullable<ActionWorkflow>>(null);
 	const [activeWorkflowSub, setActiveWorkflowSub] = useState<Nullable<Subscription>>(null);
-	const [hoveredPlayer, setHoveredPlayer] = useState<Nullable<PlayerInGameDto>>(null);
-	window.clearTimeout(closeHoverTimeout.value);
+	// const [hoveredPlayer, setHoveredPlayer] = useState<Nullable<PlayerInGameDto>>(null);
+	// window.clearTimeout(closeHoverTimeout.value);
 
-	const showPlayerArea = (player: PlayerInGameDto) => {
-		if (!_.isNil(hoveredPlayer)) {
-			return;
-		}
-		setHoveredPlayer(player);
-	};
+	// const showPlayerArea = (player: PlayerInGameDto) => {
+	// 	if (!_.isNil(hoveredPlayer)) {
+	// 		return;
+	// 	}
+	// 	setHoveredPlayer(player);
+	// };
 
-	const hidePlayerArea = () => {
-		setHoveredPlayer(null);
-	};
+	// const hidePlayerArea = () => {
+	// 	setHoveredPlayer(null);
+	// };
 
-	useEffect(() => {
-		document.addEventListener("keydown", hidePlayerArea, false);
-		return () => {
-			document.removeEventListener("keydown", hidePlayerArea);
-		};
-	}, []);
+	// useEffect(() => {
+	// 	document.addEventListener("keydown", hidePlayerArea, false);
+	// 	return () => {
+	// 		document.removeEventListener("keydown", hidePlayerArea);
+	// 	};
+	// }, []);
 
 	const showDialog = isDialogView(activeView);
 
@@ -285,7 +285,7 @@ const GamePage = () => {
 			{_.map(players, (p, index) => (
 				<div key={p.id} className={classes.playerBox}>
 					<PlayerBox player={p} index={index + 1} />
-					<div className="hoverTrap" onMouseEnter={() => showPlayerArea(p)} onMouseLeave={() => (closeHoverTimeout.value = window.setTimeout(hidePlayerArea, 250))}></div>
+					{/* <div className="hoverTrap" onMouseEnter={() => showPlayerArea(p)} onMouseLeave={() => (closeHoverTimeout.value = window.setTimeout(hidePlayerArea, 250))}></div> */}
 				</div>
 			))}
 			{_.map([...game.gameLogs].reverse(), (log, index) => (
@@ -326,7 +326,7 @@ const GamePage = () => {
 							)}
 							{activeView === ActiveView.PlayerAreas && <PlayerAreas players={players} />}
 							{activeView === ActiveView.NotesAndSettings && <PlayerConfig gameId={game.id} />}
-							{!useMobileLayout && !_.isNil(hoveredPlayer) && (
+							{/* {!useMobileLayout && !_.isNil(hoveredPlayer) && (
 								<div
 									className={classes.hoveredPlayerArea}
 									style={{
@@ -338,7 +338,7 @@ const GamePage = () => {
 								>
 									<PlayerArea player={hoveredPlayer} framed={true} />
 								</div>
-							)}
+							)} */}
 							{useMobileLayout && activeView === ActiveView.MobilePlayerBoxes && PlayerBoxesAndLogs}
 						</div>
 						<Tabs

--- a/Frontend/StarGate/src/game-page/game-board/hex/Building.tsx
+++ b/Frontend/StarGate/src/game-page/game-board/hex/Building.tsx
@@ -33,13 +33,13 @@ function getBuildingScale(type: BuildingType, onMap = false): number {
 		default:
 			return 0;
 		case BuildingType.PlanetaryInstitute:
-			return 1;
+			return onMap ? 0.9 : 1;
 		case BuildingType.AcademyLeft:
 		case BuildingType.AcademyRight:
-			return 0.9;
+			return onMap ? 0.75 : 0.9;
 		case BuildingType.ResearchLab:
 		case BuildingType.TradingStation:
-			return onMap ? 1.25 : 1.5;
+			return onMap ? 1.15 : 1.5;
 		case BuildingType.Gaiaformer:
 		case BuildingType.Mine:
 			return onMap ? 1.5 : 2;

--- a/Frontend/StarGate/src/game-page/game-board/hex/Hex.tsx
+++ b/Frontend/StarGate/src/game-page/game-board/hex/Hex.tsx
@@ -1,6 +1,7 @@
 import Tooltip from "@material-ui/core/Tooltip";
 import _ from "lodash";
 import { useSelector } from "react-redux";
+import FederationMarker from "../../../assets/Resources/Markers/RecordToken.png";
 import GaiaMarker from "../../../assets/Resources/GaiaMarker.png";
 import IvitsSpaceStation from "../../../assets/Resources/Markers/SpaceStation.png";
 import { BuildingType, PlanetType, Race } from "../../../dto/enums";
@@ -57,6 +58,7 @@ const Hex = ({ hex, width }: HexProps) => {
 	const hasIvitsSpaceStation = !!hex.ivitsSpaceStation;
 	const building = hex.building;
 	const hasBuilding = !_.isNil(building);
+	const hasFederationMarker = hasBuilding && building.showFederationMarker;
 	const lantidsMine = hex.lantidsParasiteBuilding;
 	const hasLantidsMine = !_.isNil(lantidsMine);
 	const hasSatellites = !_.isEmpty(hex.satellites);
@@ -73,6 +75,7 @@ const Hex = ({ hex, width }: HexProps) => {
 			{hasBuilding && building.type !== BuildingType.LostPlanet && (
 				<div className={classes.building} style={{ width, height }}>
 					<Building raceId={building.raceId} type={building.type} onMap={true} />
+					{hasFederationMarker && <img className={classes.federationMarker} src={FederationMarker} alt="" />}
 				</div>
 			)}
 			{hasLantidsMine && (

--- a/Frontend/StarGate/src/game-page/game-board/hex/hex.styles.ts
+++ b/Frontend/StarGate/src/game-page/game-board/hex/hex.styles.ts
@@ -70,6 +70,13 @@ const useStyles = makeStyles(() =>
 			position: "absolute",
 			zIndex: 1,
 		},
+		federationMarker: {
+			position: "absolute",
+			width: ({ width }: HexSizingProps) => width * 0.35,
+			height: ({ width }: HexSizingProps) => width * 0.35,
+			bottom: ({ height }: HexSizingProps) => (height * 0.3) / 2,
+			left: ({ width }: HexSizingProps) => (width * 0.3) / 2,
+		},
 		lantidsMine: {
 			position: "absolute",
 			top: ({ height }: HexSizingProps) => (height * 0.25) / 2,

--- a/Frontend/StarGate/src/game-page/main-view/MainView.tsx
+++ b/Frontend/StarGate/src/game-page/main-view/MainView.tsx
@@ -32,7 +32,7 @@ const MainView = ({ game, width, height, showMinimaps, minimapClicked }: MainVie
 						<ScoringTrack board={game.boardState.scoringBoard} />
 						<div className="click-trap" onClick={() => minimapClicked(ActiveView.ScoringBoard)}></div>
 					</div>
-					<div className={`${classes.miniMap} ${classes.researchBoard}`}>
+					<div className={`${classes.miniMap} zoomable ${classes.researchBoard}`}>
 						<ResearchBoard board={game.boardState.researchBoard} width={width * 0.3} height={height * 0.3} />
 						<div className="click-trap" onClick={() => minimapClicked(ActiveView.ResearchBoard)}></div>
 					</div>

--- a/Frontend/StarGate/src/game-page/main-view/main-view.styles.ts
+++ b/Frontend/StarGate/src/game-page/main-view/main-view.styles.ts
@@ -23,6 +23,9 @@ const useStyles = makeStyles(theme =>
 			"&:hover": {
 				zIndex: 2,
 			},
+			"&.zoomable:hover": {
+				zoom: 2,
+			},
 			"& > .click-trap": {
 				...fillParentAbs,
 				pointerEvents: "all",


### PR DESCRIPTION
- Unchecked rollbacks
- Remove the hover trigger  on Player Boxes that shows player areas. Maybe will come back in the form of a button
- Zoom the research track when hovering it from the main view (no mobile)
- Add federation token marker to one of the buildings of a federation that required no satellites
- Remove the useless "Incomes have been updated" sublog
- Refactor some viewmodels (change to auto properties)